### PR TITLE
fix(dtype): fix numpy float error

### DIFF
--- a/ladybug_pandas/extension_types/dtype.py
+++ b/ladybug_pandas/extension_types/dtype.py
@@ -115,7 +115,10 @@ class LadybugDType(ExtensionDtype):
 
     @property
     def type(self):
-        return float
+        try:
+            return np.float
+        except AttributeError:
+            return float
 
     @property
     def _is_numeric(self):

--- a/ladybug_pandas/extension_types/dtype.py
+++ b/ladybug_pandas/extension_types/dtype.py
@@ -115,7 +115,7 @@ class LadybugDType(ExtensionDtype):
 
     @property
     def type(self):
-        return np.float
+        return float
 
     @property
     def _is_numeric(self):


### PR DESCRIPTION
numpy.float is deprecated in numpy versions 1.24.0 and after and therefore, returning a np.float object gives an error. In order to re produce the error, you;ll have to 

1. Create a virtual env using python 3.8
2. Install ladybug-charts that dependents on ladybug-pandas
3. bump numpy version to 1.24.1

You should be able to see in any of the charts.
`AttributeError: module 'numpy' has no attribute 'float'`

read more [here](https://stackoverflow.com/a/74861894/5062912) if you are interested. 